### PR TITLE
Hides uninitialised accordion content to avoid FOUC

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -50,6 +50,19 @@
   position: relative;
 }
 
+[data-name="Accordion Heading"] ~ * {
+  display: none;
+}
+
+.mode-interact [data-name="Accordion Heading"] ~ *,
+[data-name="Accordion Heading"] ~ [data-name="End of Accordion Group"] ~ * {
+  display: inherit;
+}
+
+script {
+  display: none;
+}
+
 /* PREVIEW */
 
 [data-toggle="collapse"] {


### PR DESCRIPTION
FOUC - Flash of Unstyled Content

- Hides any content that is between **Accordion Heading** and **End of Accordion Group** components. The content will be wrapped via JavaScript into accordions.
- `script { display: none; }` is added as `display: inherit;` appears to render the content of `<script>` tags.
- **Note:** This hides all the content between  **Accordion Heading** and **End of Accordion Group** components, except when the content isn't wrapped by any tags since plaintext can't be captured by CSS selectors.

Ref. https://github.com/Fliplet/fliplet-studio/issues/2796