### PR TITLE
[Fix] Ensure only the highlighted accordion will be opened when Enter or Space is pressed

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -194,7 +194,7 @@
   $(document)
     .on('keydown', Collapsible.SELECTORS.collapsible, function(event) {
       if (event.keyCode === 13 || event.keyCode === 32) {
-        $(event.target).find('.collapse').collapse('toggle');
+        $(event.target).find(Collapsible.SELECTORS.collapse).collapse('toggle');
       }
     })
     .on('show.bs.collapse', Collapsible.SELECTORS.collapse, function(){

--- a/js/build.js
+++ b/js/build.js
@@ -194,7 +194,7 @@
   $(document)
     .on('keydown', Collapsible.SELECTORS.collapsible, function(event) {
       if (event.keyCode === 13 || event.keyCode === 32) {
-        $(Collapsible.SELECTORS.collapse).collapse('toggle');
+        $(event.target).find('.collapse').collapse('toggle');
       }
     })
     .on('show.bs.collapse', Collapsible.SELECTORS.collapse, function(){


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-27

## Description
The only selected accordion will be opened when Enter or Space pressed

## Screenshots/screencasts
https://share.getcloudapp.com/jkuZXqrA

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko